### PR TITLE
レシートプリンタでAPIで提供された文字列を使用するようにする

### DIFF
--- a/Micon.LotterySystem.Desktop/Models/ReceiptModels.cs
+++ b/Micon.LotterySystem.Desktop/Models/ReceiptModels.cs
@@ -30,6 +30,18 @@ public class IssueTicketsResponse
     [JsonPropertyName("lotteryGroupName")]
     public string? LotteryGroupName { get; set; }
 
+    [JsonPropertyName("ticketLabel")]
+    public string? TicketLabel { get; set; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+
+    [JsonPropertyName("warningText")]
+    public string? WarningText { get; set; }
+
+    [JsonPropertyName("footerText")]
+    public string? FooterText { get; set; }
+
     [JsonPropertyName("error")]
     public string? Error { get; set; }
 }

--- a/Micon.LotterySystem.Desktop/Models/ReceiptPrintJob.cs
+++ b/Micon.LotterySystem.Desktop/Models/ReceiptPrintJob.cs
@@ -19,6 +19,10 @@ public class ReceiptPrintJob
 
     public string PrinterName { get; init; } = string.Empty;
 
+    public string TicketLabel { get; init; } = "抽選券";
+
+    public string Description { get; init; } = string.Empty;
+
     public IReadOnlyList<string> WarningLines { get; init; } = Array.Empty<string>();
 
     public string FooterText { get; init; } = string.Empty;

--- a/Micon.LotterySystem.Desktop/Services/TicketRenderService.cs
+++ b/Micon.LotterySystem.Desktop/Services/TicketRenderService.cs
@@ -69,8 +69,6 @@ public class TicketRenderService : ITicketRenderService
                 ? "抽選券"
                 : printJob.TicketLabel.Trim();
 
-            const string titleLine2 = "抽選券";
-
             var descriptionText = string.IsNullOrWhiteSpace(printJob.Description)
                 ? string.Empty
                 : printJob.Description.Trim();
@@ -84,13 +82,12 @@ public class TicketRenderService : ITicketRenderService
             var spacingLarge = 28;
 
             var titleLine1Height = MeasureTextHeight(titlePaint);
-            var titleLine2Height = MeasureTextHeight(titlePaint);
             var numberHeight = MeasureTextHeight(numberPaint);
             var bodyHeight = MeasureTextHeight(bodyPaint);
             var footerHeight = MeasureTextHeight(footerPaint);
             var qrSize = _layoutSettings.QrSizePx;
 
-            var labelHeight = MeasureTextTitle(titlePaint, ticketLabel);
+            var labelHeight = MeasureTextHeight(titlePaint);
             var descHeight = string.IsNullOrWhiteSpace(descriptionText)
                 ? 0
                 : MeasureTextHeight(titlePaint);
@@ -98,8 +95,6 @@ public class TicketRenderService : ITicketRenderService
             var totalHeight =
                 topMargin +
                 titleLine1Height +
-                spacingSmall +
-                titleLine2Height +
                 spacingSmall +
                 labelHeight +
                 (string.IsNullOrWhiteSpace(descriptionText) ? 0 : spacingSmall + descHeight) +
@@ -121,8 +116,6 @@ public class TicketRenderService : ITicketRenderService
             var y = topMargin;
 
             y = DrawCenteredText(canvas, titleLine1, titlePaint, y);
-            y += spacingSmall;
-            y = DrawCenteredText(canvas, titleLine2, titlePaint, y);
             y += spacingSmall;
             y = DrawCenteredText(canvas, ticketLabel, titlePaint, y);
 
@@ -230,13 +223,6 @@ public class TicketRenderService : ITicketRenderService
 
     private static int MeasureTextHeight(SKPaint paint)
     {
-        var metrics = paint.FontMetrics;
-        return (int)Math.Ceiling(metrics.Descent - metrics.Ascent);
-    }
-
-    private static int MeasureTextTitle(SKPaint paint, string text)
-    {
-        if (string.IsNullOrWhiteSpace(text)) return 0;
         var metrics = paint.FontMetrics;
         return (int)Math.Ceiling(metrics.Descent - metrics.Ascent);
     }

--- a/Micon.LotterySystem.Desktop/Services/TicketRenderService.cs
+++ b/Micon.LotterySystem.Desktop/Services/TicketRenderService.cs
@@ -65,7 +65,16 @@ public class TicketRenderService : ITicketRenderService
                 ? "抽選会"
                 : printJob.LotteryGroupName.Trim();
 
+            var ticketLabel = string.IsNullOrWhiteSpace(printJob.TicketLabel)
+                ? "抽選券"
+                : printJob.TicketLabel.Trim();
+
             const string titleLine2 = "抽選券";
+
+            var descriptionText = string.IsNullOrWhiteSpace(printJob.Description)
+                ? string.Empty
+                : printJob.Description.Trim();
+
             var numberText = $"No.{printJob.TicketNumber}";
 
             var topMargin = _layoutSettings.MarginTop;
@@ -81,11 +90,19 @@ public class TicketRenderService : ITicketRenderService
             var footerHeight = MeasureTextHeight(footerPaint);
             var qrSize = _layoutSettings.QrSizePx;
 
+            var labelHeight = MeasureTextTitle(titlePaint, ticketLabel);
+            var descHeight = string.IsNullOrWhiteSpace(descriptionText)
+                ? 0
+                : MeasureTextHeight(titlePaint);
+
             var totalHeight =
                 topMargin +
                 titleLine1Height +
                 spacingSmall +
                 titleLine2Height +
+                spacingSmall +
+                labelHeight +
+                (string.IsNullOrWhiteSpace(descriptionText) ? 0 : spacingSmall + descHeight) +
                 spacingMedium +
                 10 + // 区切り線領域
                 spacingMedium +
@@ -106,6 +123,14 @@ public class TicketRenderService : ITicketRenderService
             y = DrawCenteredText(canvas, titleLine1, titlePaint, y);
             y += spacingSmall;
             y = DrawCenteredText(canvas, titleLine2, titlePaint, y);
+            y += spacingSmall;
+            y = DrawCenteredText(canvas, ticketLabel, titlePaint, y);
+
+            if (!string.IsNullOrWhiteSpace(descriptionText))
+            {
+                y += spacingSmall;
+                y = DrawCenteredText(canvas, descriptionText, titlePaint, y);
+            }
 
             y += spacingMedium;
             canvas.DrawLine(
@@ -205,6 +230,13 @@ public class TicketRenderService : ITicketRenderService
 
     private static int MeasureTextHeight(SKPaint paint)
     {
+        var metrics = paint.FontMetrics;
+        return (int)Math.Ceiling(metrics.Descent - metrics.Ascent);
+    }
+
+    private static int MeasureTextTitle(SKPaint paint, string text)
+    {
+        if (string.IsNullOrWhiteSpace(text)) return 0;
         var metrics = paint.FontMetrics;
         return (int)Math.Ceiling(metrics.Descent - metrics.Ascent);
     }

--- a/Micon.LotterySystem.Desktop/ViewModels/ReceiptViewModel.cs
+++ b/Micon.LotterySystem.Desktop/ViewModels/ReceiptViewModel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Threading.Tasks;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -151,6 +152,32 @@ public partial class ReceiptViewModel : ViewModelBase
                 ? LotteryGroup.Name
                 : result.LotteryGroupName;
 
+            var ticketLabel = string.IsNullOrWhiteSpace(result.TicketLabel)
+                ? "抽選券"
+                : result.TicketLabel;
+
+            var description = result.Description ?? string.Empty;
+
+            var footerText = string.IsNullOrWhiteSpace(result.FooterText)
+                ? _receiptLayoutSettings.FooterText
+                : result.FooterText;
+
+            // WarningTextを改行で分割（空行をフィルタ）
+            var warningLines = new List<string>();
+            if (!string.IsNullOrWhiteSpace(result.WarningText))
+            {
+                warningLines = result.WarningText
+                    .Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries)
+                    .Select(x => x.Trim())
+                    .Where(x => !string.IsNullOrWhiteSpace(x))
+                    .ToList();
+            }
+            // APIのWarningTextが空の場合は設定値を使用
+            if (warningLines.Count == 0)
+            {
+                warningLines = _receiptLayoutSettings.WarningLines.ToList();
+            }
+
             PrintTotal = result.Tickets.Count;
 
             foreach (var ticket in result.Tickets)
@@ -203,8 +230,10 @@ public partial class ReceiptViewModel : ViewModelBase
                     QrCodePngBytes = qrCodeImage,
                     ActivateOnIssue = ActivateOnIssue,
                     PrinterName = _printerSettings.PrinterName,
-                    WarningLines = _receiptLayoutSettings.WarningLines,
-                    FooterText = _receiptLayoutSettings.FooterText
+                    TicketLabel = ticketLabel,
+                    Description = description,
+                    WarningLines = warningLines,
+                    FooterText = footerText
                 };
 
                 var printResult = await _receiptPrinterService.PrintAsync(printJob);


### PR DESCRIPTION
## やったこと

  - チケット印刷データのカスタマイズ機能を追加
    - TicketInfo モデルに TicketLabel、WarningText、FooterText を追加（マイグレーション付き）
    - API（ReceiptController）のレスポンスにこれらの表示テキストを含めるよう変更
    - Desktop アプリ（ReceiptViewModel）でAPIから受け取った値を印刷ジョブに反映
    - レシートプリンターの券面レンダリング（TicketRenderService）で ticketLabel・description を表示
    - PDF生成（TicketPdfGenerator）でも表示テキストを反映し、改行や空行に対応
    - フロントエンドにチケットカスタマイズUI（TicketCustomizer.svelte、ticket-settings/+page.svelte）を追加
    - TicketInfoController / TicketInfoResponse を追加し、フロントエンドからチケット情報を設定可能に
    - Desktop アプリのデプロイワークフロー（deploy-desktop.yml）を追加

##  やってないこと

  - レシートプリンターの物理印刷テスト（実機確認が必要）
  - フロントエンドのチケットカスタマイズUIの動作確認（スクリーンショット等での検証）
  - 既存チケットへの表示テキスト変更の遡及適用（新規発行分のみ反映）

 ## 確認したこと

  - API → Desktop → レンダリングのデータフローが一貫していること
  - フォールバック値が適切に設定されていること（TicketLabel 空 → "抽選券" 等）
  - WarningText の改行分割・空行フィルタリングが正しく動作すること
  - PDF生成での Description / WarningText の改行表示が正しいこと
